### PR TITLE
Static Tenders pages file structures and bottom links

### DIFF
--- a/static/src/closed_tenders/index.html
+++ b/static/src/closed_tenders/index.html
@@ -109,5 +109,12 @@ label:  מכרזים קודמים
 </div>
 
 <div class = "ui centered row">
-    <button class="ui primary basic button">למכרזים פתוחים</button>
+      מאגרי מידע נוספים:
+      <div class="ui buttons">
+        <button href="#" class="ui green basic button">מכרזים פתוחים</button>
+        <button href="#" class="ui red basic button">דו״חות</button></a>
+        <button href="#" class="ui blue basic button">פרוטוקולים</button>
+        <button href="#" class="ui purple basic button">תקנות וחוקי עזר</button>
+      </div>
+    </div>
 </div>

--- a/static/src/open_tenders/index.html
+++ b/static/src/open_tenders/index.html
@@ -90,8 +90,15 @@ label: מכרזים פתוחים
   </table>
   </div>
 
-  <div class = "centered row">
-    <button class="ui primary basic button"> למכרזים קודמים</button>
+  <div class = "ui centered row">
+        מאגרי מידע נוספים:
+        <div class="ui buttons">
+          <button href="#" class="ui green basic button">מכרזים קודמים</button>
+          <button href="#" class="ui red basic button">דו״חות</button></a>
+          <button href="#" class="ui blue basic button">פרוטוקולים</button>
+          <button href="#" class="ui purple basic button">תקנות וחוקי עזר</button>
+        </div>
+      </div>
   </div>
 
 


### PR DESCRIPTION
#303 
* fixed files structure (following https://github.com/Gizra/Municipality/pull/299#issuecomment-307610742)
* added links to other data sources:

open tenders:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/3581741/27009431-23403264-4e97-11e7-9e2d-16b437eefafa.png">

closed tenders:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/3581741/27009437-34df4a64-4e97-11e7-8631-9ed0ca4e2361.png">
