### PR TITLE
Mandatory user types in all group content.

### DIFF
--- a/server/hedley/modules/custom/hedley_action/hedley_action.features.field_instance.inc
+++ b/server/hedley/modules/custom/hedley_action/hedley_action.features.field_instance.inc
@@ -295,7 +295,7 @@ function hedley_action_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_user_types',
     'label' => 'User types',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,

--- a/server/hedley/modules/custom/hedley_event/hedley_event.features.field_instance.inc
+++ b/server/hedley/modules/custom/hedley_event/hedley_event.features.field_instance.inc
@@ -428,7 +428,7 @@ function hedley_event_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_user_types',
     'label' => 'User types',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,

--- a/server/hedley/modules/custom/hedley_page/hedley_page.features.field_instance.inc
+++ b/server/hedley/modules/custom/hedley_page/hedley_page.features.field_instance.inc
@@ -90,7 +90,7 @@ function hedley_page_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_user_types',
     'label' => 'User types',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,

--- a/wdio/specs/action.js
+++ b/wdio/specs/action.js
@@ -21,11 +21,15 @@ describe('Municipality action page', () => {
 
   it('should not be able to add action without a link or a section', () => {
     // Go to the add new action page.
-    browser.url('/node/add/action?language=en');
+    browser.url('/tuba-zangariyye/node/add/action?language=en');
     browser.waitForVisible('label=Title');
 
     const titleInput = $('#edit-title-field-en-0-value');
     titleInput.setValue('Test');
+
+    // Check user type (required value).
+    const businessUserType = $('#edit-field-user-types-und input:nth-child(1)');
+    businessUserType.click();
 
     // Click the save button.
     $('#edit-submit').click();
@@ -36,11 +40,15 @@ describe('Municipality action page', () => {
 
   it('should be able to add action with a link', () => {
     // Go to the add new action page.
-    browser.url('/node/add/action?language=en');
+    browser.url('/tuba-zangariyye/node/add/action?language=en');
     browser.waitForVisible('label=Title');
 
     const titleInput = $('#edit-title-field-en-0-value');
     titleInput.setValue('Test action');
+
+    // Check user type (required value).
+    const businessUserType = $('#edit-field-user-types-und input:nth-child(1)');
+    businessUserType.click();
 
     const linkInput = $('#edit-field-link-und-0-title');
     linkInput.setValue('Test link');


### PR DESCRIPTION
#581 

@liatsade @noamoss Added the mandatory setting to this field in the following content types (the rest have it as required already):

- action
- event
- page